### PR TITLE
Make demo script more portable and CI friendly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,8 @@ repos:
       entry: alpine/helm:3.11.1 lint diracx/
       always_run: true
       pass_filenames: false
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.9.0
+    hooks:
+    - id: shellcheck

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -99,7 +99,7 @@ declare -a pkg_dirs=()
 declare -a pkg_names=()
 for src_dir in "$@"; do
   # shellcheck disable=SC2044
-  for pkg_dir in $(find "$src_dir/src" -type f -mindepth 2 -maxdepth 2 -name '__init__.py'); do
+  for pkg_dir in $(find "$src_dir/src" -mindepth 2 -maxdepth 2 -type f -name '__init__.py'); do
     pkg_dirs+=("$(dirname "${pkg_dir}")")
     pkg_name="$(basename "$(dirname "${pkg_dir}")")"
 


### PR DESCRIPTION
By default macOS comes with an ancient version of bash (as zsh is the "preffered" shell). Normally I'd advocate for sticking to POSIX-sh for compatibility but the demo script is complex enough that it's nice to use actual bash and deal with the platform specificities.