### PR TITLE
Add checksum of secrets to diracx deployment annotations

### DIFF
--- a/diracx/templates/deployment.yaml
+++ b/diracx/templates/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "diracx.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        checksum/settings: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
         {{- include "diracx.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
This means the deployment get's rolled out again when the secrets change.