### PR TITLE
 Fix regex in determining other hostname

### DIFF
--- a/run_demo.sh
+++ b/run_demo.sh
@@ -134,7 +134,7 @@ fi
 # address/IP-address.
 machine_hostname=$(hostname | tr '[:upper:]' '[:lower:]')
 if ! check_hostname "${machine_hostname}"; then
-  machine_hostname=$(ifconfig | grep 'inet ' | grep -v '127.\d.\d.\d' | awk '{ print $2 }' | head -n 1 | cut -d '/' -f 1)
+  machine_hostname=$(ifconfig | grep 'inet ' | awk '{ print $2 }' | grep -v '^127' | head -n 1 | cut -d '/' -f 1)
   if ! check_hostname "${machine_hostname}"; then
     echo "Failed to find an appropriate hostname for the demo."
     exit 1

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -139,6 +139,7 @@ if ! check_hostname "${machine_hostname}"; then
     echo "Failed to find an appropriate hostname for the demo."
     exit 1
   fi
+  printf "%b Using Hostname  %s instead \n" ${INFO_EMOJI} "${machine_hostname}"
 fi
 
 trap "cleanup" EXIT

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -139,7 +139,7 @@ if ! check_hostname "${machine_hostname}"; then
     echo "Failed to find an appropriate hostname for the demo."
     exit 1
   fi
-  printf "%b Using Hostname  %s instead \n" ${INFO_EMOJI} "${machine_hostname}"
+  printf "%b Using IP address %s instead \n" ${INFO_EMOJI} "${machine_hostname}"
 fi
 
 trap "cleanup" EXIT

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -134,7 +134,7 @@ fi
 # address/IP-address.
 machine_hostname=$(hostname | tr '[:upper:]' '[:lower:]')
 if ! check_hostname "${machine_hostname}"; then
-  machine_hostname=$(ifconfig | grep 'inet ' | grep -v '127' | awk '{ print $2 }' | head -n 1 | cut -d '/' -f 1)
+  machine_hostname=$(ifconfig | grep 'inet ' | grep -v '127.\d.\d.\d' | awk '{ print $2 }' | head -n 1 | cut -d '/' -f 1)
   if ! check_hostname "${machine_hostname}"; then
     echo "Failed to find an appropriate hostname for the demo."
     exit 1


### PR DESCRIPTION
Fix a bug in which the line machine_hostname=$(ifconfig | grep 'inet ' | grep -v '127' | awk '{ print $2 }' | head -n 1 | cut -d '/' -f 1) will completely fail, because of the chance that the other ip address will contain a 127 as well, eg 172.24.127.255