### PR TITLE
Collect coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ TODO
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| developer.enableCoverage | bool | `false` |  |
 | developer.enabled | bool | `true` |  |
 | developer.modulesToInstall | list | `[]` |  |
 | developer.sourcePath | string | `"/diracx_source"` |  |

--- a/diracx/templates/deployment.yaml
+++ b/diracx/templates/deployment.yaml
@@ -54,12 +54,21 @@ spec:
         - name: signing-key-mount
           emptyDir:
           sizeLimit: 5Mi
+        {{- if and .Values.developer.enabled .Values.developer.enableCoverage }}
+        - name: coverage-data
+          persistentVolumeClaim:
+            claimName: pvc-coverage
+        {{- end }}
 
       {{/* Define common volume mounts for reusability */}}
       {{- $commonVolumeMounts := list }}
       {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" "/cs_store" "name" "cs-store-mount" "readOnly" false) }}
       {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" "/signing-key" "name" "signing-key-mount" "readOnly" false) }}
       {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" "/entrypoint.sh" "name" "container-entrypoint" "subPath" "entrypoint.sh") }}
+      {{- if and .Values.developer.enabled .Values.developer.enableCoverage }}
+      {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" "/diracx-coveragerc" "name" "container-entrypoint" "subPath" "coveragerc") }}
+      {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" "/coverage-reports" "name" "coverage-data" "readOnly" false) }}
+      {{- end }}
       {{- if and .Values.developer.enabled .Values.developer.modulesToInstall }}
       {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" .Values.developer.sourcePath "name" "diracx-code-mount" "readOnly" true) }}
       {{- range $module := .Values.developer.modulesToInstall }}

--- a/diracx/templates/deployment.yaml
+++ b/diracx/templates/deployment.yaml
@@ -54,6 +54,19 @@ spec:
         - name: signing-key-mount
           emptyDir:
           sizeLimit: 5Mi
+
+      {{/* Define common volume mounts for reusability */}}
+      {{- $commonVolumeMounts := list }}
+      {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" "/cs_store" "name" "cs-store-mount" "readOnly" false) }}
+      {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" "/signing-key" "name" "signing-key-mount" "readOnly" false) }}
+      {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" "/entrypoint.sh" "name" "container-entrypoint" "subPath" "entrypoint.sh") }}
+      {{- if and .Values.developer.enabled .Values.developer.modulesToInstall }}
+      {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" .Values.developer.sourcePath "name" "diracx-code-mount" "readOnly" true) }}
+      {{- range $module := .Values.developer.modulesToInstall }}
+      {{- $commonVolumeMounts = append $commonVolumeMounts (dict "mountPath" (printf "%s/%s/src/%s.egg-info" $.Values.developer.sourcePath $module $module) "name" (printf "%s-editable-install" (lower $module)) "readOnly" false) }}
+      {{- end }}
+      {{- end }}
+
       initContainers:
       - name: init-cs
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -69,23 +82,7 @@ spec:
           {{- with (first .Values.dex.config.staticClients) }}
           - "--idp-client-id={{ .id }}"
           {{- end }}
-        volumeMounts:
-          - mountPath: /cs_store
-            name: cs-store-mount
-            readOnly: false
-          {{- if and .Values.developer.enabled .Values.developer.modulesToInstall }}
-          - mountPath: {{ .Values.developer.sourcePath }}
-            name: diracx-code-mount
-            readOnly: true
-          {{- range $module := .Values.developer.modulesToInstall }}
-          - mountPath: "{{ $.Values.developer.sourcePath }}/{{ $module }}/src/{{ $module }}.egg-info"
-            name: {{ lower $module }}-editable-install
-            readOnly: false
-          {{- end }}
-          {{- end }}
-          - name: container-entrypoint
-            mountPath: /entrypoint.sh
-            subPath: entrypoint.sh
+        volumeMounts: {{ toYaml $commonVolumeMounts | nindent 10 }}
       - name: init-cs-user
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command: ["bash", "/entrypoint.sh"]
@@ -97,23 +94,7 @@ spec:
           - "--vo=diracAdmin"
           - "--user-group=admin"
           - "--sub=EgVsb2NhbA"
-        volumeMounts:
-          - mountPath: /cs_store
-            name: cs-store-mount
-            readOnly: false
-          {{- if and .Values.developer.enabled .Values.developer.modulesToInstall }}
-          - mountPath: {{ .Values.developer.sourcePath }}
-            name: diracx-code-mount
-            readOnly: true
-          {{- range $module := .Values.developer.modulesToInstall }}
-          - mountPath: "{{ $.Values.developer.sourcePath }}/{{ $module }}/src/{{ $module }}.egg-info"
-            name: {{ lower $module }}-editable-install
-            readOnly: false
-          {{- end }}
-          {{- end }}
-          - name: container-entrypoint
-            mountPath: /entrypoint.sh
-            subPath: entrypoint.sh
+        volumeMounts: {{ toYaml $commonVolumeMounts | nindent 10 }}
       - name: init-signing-key
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command: [/dockerMicroMambaEntrypoint.sh]
@@ -125,29 +106,13 @@ spec:
           - "-b4096"
           - "-mPEM"
           - "-f/signing-key/rs256.key"
-        volumeMounts:
-          - mountPath: /signing-key/
-            name: signing-key-mount
-            readOnly: false
+        volumeMounts: {{ toYaml $commonVolumeMounts | nindent 10 }}
       {{- if .Values.diracx.manageSQLSchema }}
       - name: create-sql-db-schema
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command: ["bash", "/entrypoint.sh"]
         args: ["python", "-m", "diracx.db", "init-sql"]
-        volumeMounts:
-          {{- if and .Values.developer.enabled .Values.developer.modulesToInstall }}
-          - mountPath: {{ .Values.developer.sourcePath }}
-            name: diracx-code-mount
-            readOnly: true
-          {{- range $module := .Values.developer.modulesToInstall }}
-          - mountPath: "{{ $.Values.developer.sourcePath }}/{{ $module }}/src/{{ $module }}.egg-info"
-            name: {{ lower $module }}-editable-install
-            readOnly: false
-          {{- end }}
-          {{- end }}
-          - name: container-entrypoint
-            mountPath: /entrypoint.sh
-            subPath: entrypoint.sh
+        volumeMounts: {{ toYaml $commonVolumeMounts | nindent 10 }}
         envFrom:
           - secretRef:
               name: diracx-init-mysql-secrets
@@ -184,26 +149,7 @@ spec:
             - "--reload-dir={{ .Values.developer.sourcePath }}"
             {{- end }}
           {{- end }}
-          volumeMounts:
-            - mountPath: /cs_store
-              name: cs-store-mount
-              readOnly: true
-            - mountPath: /signing-key/
-              name: signing-key-mount
-              readOnly: true
-            {{- if and .Values.developer.enabled .Values.developer.modulesToInstall }}
-            - mountPath: {{ .Values.developer.sourcePath }}
-              name: diracx-code-mount
-              readOnly: true
-            {{- range $module := .Values.developer.modulesToInstall }}
-            - mountPath: "{{ $.Values.developer.sourcePath }}/{{ $module }}/src/{{ $module }}.egg-info"
-              name: {{ lower $module }}-editable-install
-              readOnly: false
-            {{- end }}
-            {{- end }}
-            - name: container-entrypoint
-              mountPath: /entrypoint.sh
-              subPath: entrypoint.sh
+          volumeMounts: {{ toYaml $commonVolumeMounts | nindent 12 }}
           envFrom:
             # - configMapRef:
             #     name: diracx-env-config

--- a/diracx/templates/diracx-container-entrypoint.yaml
+++ b/diracx/templates/diracx-container-entrypoint.yaml
@@ -15,4 +15,50 @@ data:
     pip install {{- range $moduleName := .Values.developer.modulesToInstall }} -e {{ $.Values.developer.sourcePath }}/{{ $moduleName }} {{- end }}
     {{- end }}
 
+    {{- if and .Values.developer.enabled .Values.developer.enableCoverage }}
+    SITE_PACKAGES_DIR=$(python -m sysconfig | grep platlib | head -n 1 | cut -d '=' -f 2 | cut -d '"' -f 2)
+    echo "Enabling coverage using pth file in SITE_PACKAGES_DIR=${SITE_PACKAGES_DIR}"
+    echo 'import coverage; coverage.process_startup()' > "${SITE_PACKAGES_DIR}/coverage.pth"
+    export COVERAGE_PROCESS_START=/diracx-coveragerc
+    {{- end }}
+
     exec "$@"
+  {{- if and .Values.developer.enabled .Values.developer.enableCoverage }}
+  coveragerc: |
+    [run]
+    data_file=/coverage-reports/coverage
+    relative_files=True
+    parallel=True
+    sigterm=True
+    omit =
+        */diracx/client/*
+  {{- end }}
+---
+{{/* If we're collecting coverage we also need a volume to store it in */}}
+{{- if and .Values.developer.enabled .Values.developer.enableCoverage }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-coverage
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 2Gi
+  hostPath:
+    path: /coverage-reports
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-coverage
+spec:
+  storageClassName: ""
+  volumeName: pv-coverage
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+{{ end }}

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -54,6 +54,7 @@ developer:
   # Path from which to mount source of DIRACX
   sourcePath: /diracx_source
   modulesToInstall: []
+  enableCoverage: false
   # If set, mount the CS stored localy instead of initializing a default one
   # localCSPath: /local_cs_store
 


### PR DESCRIPTION
This PR does two things:

* Simplify the deployment chart so that the `volumeMounts` come from a variable
* Adds an `--enable-coverage` flag to the demo script. This works similarly to the editable install using the entrypoint to enable coverage collecting. It isn't really intended to be used anywhere outside of CI in `diracx`.