### PR TITLE
Avoid needing to pull container images every time the demo runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,13 @@ TODO
 | diracx.settings.DIRACX_CONFIG_BACKEND_URL | string | `"git+file:///cs_store/initialRepo"` |  |
 | diracx.settings.DIRACX_SERVICE_AUTH_ALLOWED_REDIRECTS | string | `"[\"http://anything:8000/docs/oauth2-redirect\"]"` |  |
 | diracx.settings.DIRACX_SERVICE_AUTH_TOKEN_KEY | string | `"file:///signing-key/rsa256.key"` |  |
-| diracxWeb.image.pullPolicy | string | `"Always"` |  |
 | diracxWeb.image.repository | string | `"ghcr.io/diracgrid/diracx-web/static"` |  |
 | diracxWeb.image.tag | string | `"latest"` |  |
 | diracxWeb.service.port | int | `8080` |  |
 | diracxWeb.service.type | string | `"ClusterIP"` |  |
 | fullnameOverride | string | `""` |  |
 | global.batchJobTTL | int | `600` |  |
-| image.pullPolicy | string | `"Always"` |  |
+| global.imagePullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ghcr.io/diracgrid/diracx/server"` |  |
 | image.tag | string | `"latest"` |  |
 | ingress.annotations | object | `{}` |  |

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ TODO
 | developer.localCSPath | string | `"/local_cs_store"` |  |
 | developer.nodeImage | string | `"node:16-alpine"` |  |
 | developer.nodeModuleToInstall | string | `nil` |  |
+| developer.offline | bool | `false` |  |
 | developer.pythonModulesToEditableInstall | list | `[]` |  |
 | developer.sourcePath | string | `"/diracx_source"` |  |
 | developer.urls | object | `{}` |  |

--- a/demo/demo_cluster_conf.tpl.yaml
+++ b/demo/demo_cluster_conf.tpl.yaml
@@ -16,8 +16,7 @@ nodes:
   # Then the PV will mount it from this control plane "local" directory
   - hostPath: {{ csStorePath }}
     containerPath: /local_cs_store
-  # For developer to be able to edit
-{{ hostPaths }}
+{{ extraMounts }}
 
   # Expose the ingress port
   extraPortMappings:

--- a/demo/values.tpl.yaml
+++ b/demo/values.tpl.yaml
@@ -1,3 +1,8 @@
+global:
+  # Override the imagePullPolicy to always so we can using latest image tags
+  # without risking them being outdated.
+  imagePullPolicy: Always
+
 developer:
   urls:
     diracx: https://{{ hostname }}:8000

--- a/diracx/charts/cert-manager-issuer/templates/issuer-job.yaml
+++ b/diracx/charts/cert-manager-issuer/templates/issuer-job.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: create-issuer
           image: ghcr.io/diracgrid/diracx/secret-generation:latest
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command: ['/bin/bash', '/scripts/create-issuer', '/scripts/issuer.yml']
           volumeMounts:
             - name: scripts

--- a/diracx/templates/deployment.yaml
+++ b/diracx/templates/deployment.yaml
@@ -79,6 +79,7 @@ spec:
       {{- if .Values.diracx.manageOSIndices }}
       - name: create-os-db-indices
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         command: ["bash", "/entrypoint.sh"]
         args: ["python", "-m", "diracx.db", "init-os"]
         volumeMounts: {{ toYaml $commonVolumeMounts | nindent 10 }}
@@ -91,7 +92,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.diracx.service.port }}

--- a/diracx/templates/diracx-container-entrypoint.yaml
+++ b/diracx/templates/diracx-container-entrypoint.yaml
@@ -16,10 +16,10 @@ data:
     eval "$(micromamba shell hook --shell=posix)" && micromamba activate base
 
     {{ if .Values.diracx.pythonModulesToInstall }}
-    pip install {{- range $moduleSpec := .Values.diracx.pythonModulesToInstall }} {{ $moduleSpec }} {{- end }}
+    pip install{{ if .Values.developer.offline }} --no-build-isolation{{ end}} {{- range $moduleSpec := .Values.diracx.pythonModulesToInstall }} {{ $moduleSpec }} {{- end }}
     {{- end }}
     {{ if and .Values.developer.enabled .Values.developer.pythonModulesToEditableInstall }}
-    pip install {{- range $moduleName := .Values.developer.pythonModulesToEditableInstall }} -e {{ $.Values.developer.sourcePath }}/{{ $moduleName }} {{- end }}
+    pip install{{ if .Values.developer.offline }} --no-build-isolation{{ end}} {{- range $moduleName := .Values.developer.pythonModulesToEditableInstall }} -e {{ $.Values.developer.sourcePath }}/{{ $moduleName }} {{- end }}
     {{- end }}
 
     {{- if and .Values.developer.enabled .Values.developer.enableCoverage }}

--- a/diracx/templates/init-cs/job.yaml
+++ b/diracx/templates/init-cs/job.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command: ["/bin/bash", "/entrypoint.sh"]
           args: ["/bin/bash", "/scripts/init-cs"]
           volumeMounts:

--- a/diracx/templates/init-secrets/job.yaml
+++ b/diracx/templates/init-secrets/job.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: ghcr.io/diracgrid/diracx/secret-generation:latest
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args: ["/bin/bash", "/scripts/init-secrets"]
           volumeMounts:
             - name: scripts

--- a/diracx/templates/init-sql/job.yaml
+++ b/diracx/templates/init-sql/job.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command: ["/bin/bash", "/entrypoint.sh"]
           args: ["/bin/bash", "/scripts/init-sql"]
           volumeMounts:

--- a/diracx/templates/web-deployment.yaml
+++ b/diracx/templates/web-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- if $nodeDevInstall }}
         - name: install-deps
           image: {{ .Values.developer.nodeImage }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           # We use "npm ci" instead of "npm install" so it will use the package-lock.json file
           # rather than using the package.json file. Using package.json would fail as the mount
           # is read-only so package-lock.json can't be edited.
@@ -72,7 +72,7 @@ spec:
           {{- else }}
           image: {{ .Values.diracxWeb.image.repository }}:{{ .Values.diracxWeb.image.tag }}
           {{- end }}
-          imagePullPolicy: {{ .Values.diracxWeb.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.diracxWeb.service.port }}

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -77,6 +77,8 @@ init-sql:
 
 developer:
   enabled: true
+  # Make it possible to launch the demo without having an internet connection
+  offline: false
   # URLs which can be used to access various components of the demo
   urls: {}
   # Path from which to mount source of DIRACX

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -5,12 +5,16 @@
 global:
   # How long should batch jobs be retained after completing?
   batchJobTTL: 600
+  # TODO: To avoid being unable to launch a container when the remote registry
+  # is down this should be changed to IfNotPresent once we start using tags.
+  # For now we override it to Always to avoid confusion around having an
+  # outdated reference to the "latest" tag.
+  imagePullPolicy: Always
 
 replicaCount: 1
 
 image:
   repository: ghcr.io/diracgrid/diracx/server
-  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
@@ -128,7 +132,6 @@ ingress:
 diracxWeb:
   image:
     repository: ghcr.io/diracgrid/diracx-web/static
-    pullPolicy: Always
     tag: latest
   service:
     type: ClusterIP

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -224,7 +224,7 @@ cp "${script_dir}/demo/demo_cluster_conf.tpl.yaml" "${demo_dir}/demo_cluster_con
 if [ ${#pkg_dirs[@]} -gt 0 ]; then
   for pkg_dir in "${pkg_dirs[@]}"; do
     mv "${demo_dir}/demo_cluster_conf.yaml" "${demo_dir}/demo_cluster_conf.yaml.bak"
-    sed "s@{{ hostPaths }}@  - hostPath: ${pkg_dir}\n    containerPath: /diracx_source/$(basename "${pkg_dir}")\n{{ hostPaths }}@g" "${demo_dir}/demo_cluster_conf.yaml.bak" > "${demo_dir}/demo_cluster_conf.yaml"
+    sed "s@{{ extraMounts }}@  - hostPath: ${pkg_dir}\n    containerPath: /diracx_source/$(basename "${pkg_dir}")\n{{ extraMounts }}@g" "${demo_dir}/demo_cluster_conf.yaml.bak" > "${demo_dir}/demo_cluster_conf.yaml"
   done
 fi
 # Add the mount for the CS
@@ -241,11 +241,11 @@ if [[ ${enable_coverage} ]]; then
   # Make sure the directory is writable by the container
   chmod 777 "${demo_dir}/coverage-reports"
   mv "${demo_dir}/demo_cluster_conf.yaml" "${demo_dir}/demo_cluster_conf.yaml.bak"
-  sed "s@{{ hostPaths }}@  - hostPath: ${demo_dir}/coverage-reports\n    containerPath: /coverage-reports\n{{ hostPaths }}@g" "${demo_dir}/demo_cluster_conf.yaml.bak" > "${demo_dir}/demo_cluster_conf.yaml"
+  sed "s@{{ extraMounts }}@  - hostPath: ${demo_dir}/coverage-reports\n    containerPath: /coverage-reports\n{{ extraMounts }}@g" "${demo_dir}/demo_cluster_conf.yaml.bak" > "${demo_dir}/demo_cluster_conf.yaml"
 fi
-# Cleanup the "{{ hostPaths }}" part of the template and make sure things look reasonable
+# Cleanup the "{{ extraMounts }}" part of the template and make sure things look reasonable
 mv "${demo_dir}/demo_cluster_conf.yaml" "${demo_dir}/demo_cluster_conf.yaml.bak"
-sed "s@{{ hostPaths }}@@g" "${demo_dir}/demo_cluster_conf.yaml.bak" > "${demo_dir}/demo_cluster_conf.yaml"
+sed "s@{{ extraMounts }}@@g" "${demo_dir}/demo_cluster_conf.yaml.bak" > "${demo_dir}/demo_cluster_conf.yaml"
 if grep '{{' "${demo_dir}/demo_cluster_conf.yaml"; then
   printf "%b Error generating Kind template. Found {{ in the template result\n" ${UNICORN_EMOJI}
   exit 1

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -132,7 +132,7 @@ while [ -n "${1:-}" ]; do case $1 in
 	# Invalid option: abort
 	--*|-?*)
 		>&2 printf '%b %s: Invalid option: "%s"\n' ${SKULL_EMOJI} "${0##*/}" "$1"
-		>&2 printf 'Usage: %s\n' "$usage"
+		>&2 printf 'Usage: %b\n' "$usage"
 		exit 1 ;;
 
 	# Argument not prefixed with a dash


### PR DESCRIPTION
Currently each time the demo runs the container images must be downloaded. This is O(5GB) of stuff that can't be easily reduced (OpenSearch is 2GB by itself). This makes the demo very painful on slow internet connections. Ideally we want to be able to run the demo offline at times.

To mitigate this, we can mount Kind's containerd storage from the host. This has downsides (most notably that it will grow without bound as there is no garbage collection) but is worthwhile at least some of the time. For now I've hidden this behind a `--mount-containerd` flag.