### PR TITLE
Fix installing VCS URLs in diracx-container-entrypoint.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ helm diff upgrade diracx-demo ./diracx --values .demo/values.yaml
 helm upgrade diracx-demo ./diracx --values .demo/values.yaml
 ```
 
+## Deploying a custom branch to DIRAC certification
+
+Apply the following on top of the standard `values.yaml` file, replacing `USERNAME` and `BRANCH_NAME` with the appropriate values.
+
+```yaml
+global:
+  images:
+    tag: "dev"
+    # TODO: We should use the base images here but pythonModulesToInstall would need to be split
+    services: ghcr.io/diracgrid/diracx/services
+    client: ghcr.io/diracgrid/diracx/client
+
+diracx:
+  pythonModulesToInstall:
+    - "git+https://github.com/USERNAME/diracx.git@BRANCH_NAME#egg=diracx_core&subdirectory=diracx-core"
+    - "git+https://github.com/USERNAME/diracx.git@BRANCH_NAME#egg=diracx_db&subdirectory=diracx-db"
+    - "git+https://github.com/USERNAME/diracx.git@BRANCH_NAME#egg=diracx_routers&subdirectory=diracx-routers"yaml
+```
+
 ## Deploying in production
 
 TODO

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -41,6 +41,25 @@ helm diff upgrade diracx-demo ./diracx --values .demo/values.yaml
 helm upgrade diracx-demo ./diracx --values .demo/values.yaml
 ```
 
+## Deploying a custom branch to DIRAC certification
+
+Apply the following on top of the standard `values.yaml` file, replacing `USERNAME` and `BRANCH_NAME` with the appropriate values.
+
+```yaml
+global:
+  images:
+    tag: "dev"
+    # TODO: We should use the base images here but pythonModulesToInstall would need to be split
+    services: ghcr.io/diracgrid/diracx/services
+    client: ghcr.io/diracgrid/diracx/client
+
+diracx:
+  pythonModulesToInstall:
+    - "git+https://github.com/USERNAME/diracx.git@BRANCH_NAME#egg=diracx_core&subdirectory=diracx-core"
+    - "git+https://github.com/USERNAME/diracx.git@BRANCH_NAME#egg=diracx_db&subdirectory=diracx-db"
+    - "git+https://github.com/USERNAME/diracx.git@BRANCH_NAME#egg=diracx_routers&subdirectory=diracx-routers"yaml
+```
+
 ## Deploying in production
 
 TODO

--- a/diracx/templates/diracx-container-entrypoint.yaml
+++ b/diracx/templates/diracx-container-entrypoint.yaml
@@ -16,7 +16,7 @@ data:
     eval "$(micromamba shell hook --shell=posix)" && micromamba activate base
 
     {{ if .Values.diracx.pythonModulesToInstall }}
-    pip install{{ if .Values.developer.offline }} --no-build-isolation{{ end }} {{- range $moduleSpec := .Values.diracx.pythonModulesToInstall }} {{ $moduleSpec }} {{- end }}
+    pip install{{ if .Values.developer.offline }} --no-build-isolation{{ end }} {{- range $moduleSpec := .Values.diracx.pythonModulesToInstall }} {{ $moduleSpec | quote }} {{- end }}
     {{- end }}
     {{ if .Values.developer.mountedPythonModulesToInstall }}
     pip install{{ if .Values.developer.offline }} --no-build-isolation{{ end }} {{- range $moduleName := .Values.developer.mountedPythonModulesToInstall }} {{ if $.Values.developer.editableMountedPythonModules }}-e {{- end }}{{ $.Values.developer.sourcePath }}/{{ $moduleName }} {{- end }}


### PR DESCRIPTION
Fixes doing things like:
```yaml
diracx:
  pythonModulesToInstall:
    - "git+https://github.com/chaen/diracx.git@jobStateUpdate#egg=diracx_core&subdirectory=diracx-core"
    - "git+https://github.com/chaen/diracx.git@jobStateUpdate#egg=diracx_db&subdirectory=diracx-db"
    - "git+https://github.com/chaen/diracx.git@jobStateUpdate#egg=diracx_routers&subdirectory=diracx-routers"
```