### PR TITLE
feat: update node image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,9 +61,10 @@ jobs:
       run: |
         git clone https://github.com/DIRACGrid/diracx.git /tmp/diracx
         git clone https://github.com/DIRACGrid/DIRAC.git /tmp/DIRAC
+        git clone https://github.com/DIRACGrid/diracx-web.git /tmp/diracx-web
     - name: Start demo
       run: |
-        ./run_demo.sh --exit-when-done /tmp/diracx /tmp/DIRAC
+        ./run_demo.sh --exit-when-done /tmp/diracx /tmp/DIRAC /tmp/diracx-web
     - name: Debugging information
       run: |
         export KUBECONFIG=$PWD/.demo/kube.conf

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Depending on the installation you perform, some tasks may be necessary or not. T
 | developer.ipAlias | string | `nil` | The IP that the demo is running at |
 | developer.localCSPath | string | `"/local_cs_store"` | If set, mount the CS stored localy instead of initializing a default one |
 | developer.mountedPythonModulesToInstall | list | `[]` | List of packages which are mounted into developer.sourcePath and should be installed with pip install SOURCEPATH/... |
-| developer.nodeImage | string | `"node:16-alpine"` | Image to use for the webapp if nodeModuleToInstall is set |
+| developer.nodeImage | string | `"node:alpine"` | Image to use for the webapp if nodeModuleToInstall is set |
 | developer.nodeModuleToInstall | string | `nil` | List of node modules to install |
 | developer.offline | bool | `false` | Make it possible to launch the demo without having an internet connection |
 | developer.sourcePath | string | `"/diracx_source"` | Path from which to mount source of DIRACX |

--- a/diracx/templates/web-deployment.yaml
+++ b/diracx/templates/web-deployment.yaml
@@ -54,7 +54,6 @@ spec:
             - mountPath: "{{ .Values.developer.sourcePath }}/{{ .Values.developer.nodeModuleToInstall }}"
               name: "diracx-web-code-mount"
               subPath: "{{ .Values.developer.nodeModuleToInstall }}"
-              readOnly: true
             - mountPath: "{{ $nodeModulePath }}/node_modules"
               name: "diracx-web-scratch-node-modules"
             - mountPath: "{{ $nodeModulePath }}/.next"
@@ -85,13 +84,15 @@ spec:
               port: http
           {{- if $nodeDevInstall }}
           command: ["npm", "run", "dev", "--prefix", "{{ $nodeModulePath }}", "--", "-p", "{{ .Values.diracxWeb.service.port }}"]
+          env:
+            - name: NEXT_TELEMETRY_DISABLED
+              value: "1"
           {{- end }}
           volumeMounts:
           {{- if $nodeDevInstall }}
             - mountPath: "{{ .Values.developer.sourcePath }}/{{ .Values.developer.nodeModuleToInstall }}"
               name: "diracx-web-code-mount"
               subPath: "{{ .Values.developer.nodeModuleToInstall }}"
-              readOnly: true
             - mountPath: "{{ $nodeModulePath }}/node_modules"
               name: "diracx-web-scratch-node-modules"
             - mountPath: "{{ $nodeModulePath }}/.next"

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -97,7 +97,7 @@ developer:
   # -- List of node modules to install
   nodeModuleToInstall: null
   # -- Image to use for the webapp if nodeModuleToInstall is set
-  nodeImage: node:16-alpine
+  nodeImage: node:alpine
   # -- Enable collection of coverage reports (intended for CI usage only)
   enableCoverage: false
   # -- Enable automatic reloading inside uvicorn when the sources change

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -250,6 +250,8 @@ if [ ${#python_pkg_names[@]} -gt 0 ]; then
 fi
 if [ "${node_pkg_name}" != "" ]; then
   printf "%b Found Node package directories for: %s\n" ${UNICORN_EMOJI} "${node_pkg_name}"
+  # Ensure node_modules and .next exist, else create them, as volumes will be mounted there
+  mkdir -p "${node_pkg_name}"/node_modules "${node_pkg_name}"/.next
 fi
 
 trap "cleanup" EXIT


### PR DESCRIPTION
https://github.com/DIRACGrid/diracx-charts/pull/77 is stuck and I need to update the node image to keep working with a mounted `diracx-web` version as NextJS14 does not support `node v16` anymore (deprecated by the way).

Update: I found a minor issue where the `diracx-web` pod does not start if `node_modules` or `.next` directories do not exist. I fixed that by:
- adding a `mkdir -p` line in `run_demo`. It solves the issue and works correctly, now I am not sure whether it is elegant.
- mounting the node package in read+write mode instead of read-only: this is because `next-env.d.ts` is generated/updated by `npm run dev`. As we are in development mode, it would not a problem, wouldn't it? + There is an attempt to move this file into the `.next` directory, let's see how it goes.