### PR TITLE
Feat: DiracX-Web port environment variable and node modules size increase

### DIFF
--- a/diracx/templates/diracx-web/deployment.yaml
+++ b/diracx/templates/diracx-web/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         # start from a clean state
         - name: diracx-web-scratch-node-modules
           emptyDir:
-            sizeLimit: 1Gi
+            sizeLimit: 2Gi
         - name: diracx-web-scratch-next
           emptyDir:
             sizeLimit: 1Gi
@@ -136,10 +136,12 @@ spec:
           {{- if $nodeDevInstall }}
           # Start the node module in development mode
           image: {{ .Values.developer.nodeImage }}
-          command: ["npm", "run", "dev", "--prefix", "{{ $nodeMountedModulePath }}", "--", "-p", "{{ .Values.diracxWeb.service.port }}"]
+          command: ["npm", "run", "dev", "--prefix", "{{ $nodeMountedModulePath }}"]
           env:
             - name: NEXT_TELEMETRY_DISABLED
               value: "1"
+            - name: PORT
+              value: "{{ .Values.diracxWeb.service.port }}"
           volumeMounts:
             - mountPath: "{{ $nodeMountedModulePath }}"
               name: "diracx-web-code-mount"


### PR DESCRIPTION
This PR includes two changes:

- Port Configuration: Updates the port configuration for diracx-web to use an environment variable instead of the -p argument.
- Node_Modules Size Limit: Increases the size limit for the node_modules directory.

These changes are necessary as diracx-web transitions to a monorepo structure, making argument passing through Lerna inefficient, and the increased size limit supports the growing dependencies in the monorepo.

The -p argument is specific to the Next.js server and is not applicable to the new library, so passing it would make the command look something like:
```bash
lerna run dev --scope diracx-web-components & lerna run dev --scope diracx-web --
```
Instead of the simpler and more efficient:
```bash
lerna run dev --parallel
```

Additionally, running the library script in the background isn't a good idea because a Next.js error wouldn't stop it, leading to potential issues.

Integration tests now fail without these changes but pass with them, as the dev node script no longer supports the -p argument. Here are the test results:
[Test without these changes](https://github.com/Loxeris/diracx-web/actions/runs/9252624622),
[Test with these changes](https://github.com/Loxeris/diracx-web/actions/runs/9257231943)
