### PR TITLE
fix: increase mysql probe time when update is taking too long

### DIFF
--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -349,6 +349,18 @@ mysql:
     createDatabase: false
   initdbScriptsConfigMap: mysql-init-diracx-dbs
 
+  # if mysql pod is failing and restarting due to mysql update
+  # it can be that the prob failure treshold is too low
+  # increasing this number can help:
+  #
+  # startupProbe:
+  #   enabled: true
+  #   initialDelaySeconds: 15
+  #   periodSeconds: 10
+  #   timeoutSeconds: 1
+  #   failureThreshold: 30
+  #   successThreshold: 1
+
 ##########################
 
 rabbitmq:


### PR DESCRIPTION
Add a comment in `values.yml`, when mysql update is taking too long the pod is restarted too quickly, a fix can be to increase the probe failure treshold. 

@chaen, is that the right place for this comment ? 