### PR TITLE
feat(values): replace default diracx-web tag with dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Note that this configuration is trivial and does not follow production recommand
 | global.images.services | string | `"ghcr.io/diracgrid/diracx/services"` |  |
 | global.images.tag | string | `"dev"` |  |
 | global.images.web.repository | string | `"ghcr.io/diracgrid/diracx-web/static"` |  |
-| global.images.web.tag | string | `"latest"` |  |
+| global.images.web.tag | string | `"dev"` |  |
 | global.storageClassName | string | `"standard"` |  |
 | grafana.datasources."datasources.yaml".apiVersion | int | `1` |  |
 | grafana.datasources."datasources.yaml".datasources[0].name | string | `"Jaeger"` |  |

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -19,7 +19,7 @@ global:
     services: ghcr.io/diracgrid/diracx/services
     client: ghcr.io/diracgrid/diracx/client
     web:
-      tag: "latest"
+      tag: "dev"
       repository: ghcr.io/diracgrid/diracx-web/static
 
 replicaCount: 1


### PR DESCRIPTION
`diracx-web` now contains tags and releases. We are following `diracx` practices:
- `dev` tag: obtained each time there is a push to `main`
- `v*` tags: correspond to a given version, generated when the release-please PR is merged into `main`

There is no more `latest` tag, at least for now.