### PR TITLE
feat: Add PilotAgentsDB to sqlDbs

### DIFF
--- a/demo/values.tpl.yaml
+++ b/demo/values.tpl.yaml
@@ -34,6 +34,7 @@ diracx:
       JobLoggingDB:
       SandboxMetadataDB:
       TaskQueueDB:
+      PilotAgentsDB:
   osDbs:
     dbs:
       JobParametersDB:


### PR DESCRIPTION
Add a `PilotAgentsDB` entry to a list of SQL databases.