### PR TITLE
run_demo: disable strict-validate-path-type for nginx ingress

### DIFF
--- a/run_demo.sh
+++ b/run_demo.sh
@@ -504,8 +504,12 @@ printf "%b Creating an ingress...\n" ${UNICORN_EMOJI}
 # TODO: This should move to the chart itself
 if [ ${offline_mode} -eq 0 ]; then
   curl -L https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml > "${tmp_dir}/kind-ingress-deploy.yaml"
-  mv "${tmp_dir}/kind-ingress-deploy.yaml" "${demo_dir}/kind-ingress-deploy.yaml"
+  # Disable the strict validation of the path
+  # https://github.com/kubernetes/ingress-nginx/issues/11176
+  # https://github.com/kubernetes/ingress-nginx/issues/10200
+  sed -E 's/^data: null/data:\n  strict-validate-path-type: "false"/g'  "${tmp_dir}/kind-ingress-deploy.yaml" > "${demo_dir}/kind-ingress-deploy.yaml"
 fi
+
 "${demo_dir}/kubectl" apply -f "${demo_dir}/kind-ingress-deploy.yaml"
 printf "%b Waiting for ingress controller to be created...\n" ${UNICORN_EMOJI}
 "${demo_dir}/kubectl" wait --namespace ingress-nginx \


### PR DESCRIPTION
As of `nginx-ingress` `1.12.0`,  `strict-validate-path-type`  is enabled by [default](https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.12.0-beta.0.md?plain=1)

This means that the installation fails with the following error

```
2024-10-15T09:58:38.7322333Z Error: INSTALLATION FAILED: 1 error occurred:
2024-10-15T09:58:38.7326214Z 	* admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: ingress contains invalid paths: path /.well-known cannot be used with pathType Prefix
```

We could use an `implementationSpecific` specific path type, but I think it would be less generic. 