### PR TITLE
feat(diracx-web): support npm workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,10 @@ Note that this configuration is trivial and does not follow production recommand
 | developer.enabled | bool | `true` |  |
 | developer.ipAlias | string | `nil` | The IP that the demo is running at |
 | developer.localCSPath | string | `"/local_cs_store"` | If set, mount the CS stored localy instead of initializing a default one |
-| developer.mountedNodeModuleToInstall | string | `nil` | List of node modules to install |
+| developer.mountedNodeModuleToInstall | string | `nil` | Node module to install |
 | developer.mountedPythonModulesToInstall | list | `[]` | List of packages which are mounted into developer.sourcePath and should be installed with pip install SOURCEPATH/... |
 | developer.nodeImage | string | `"node:alpine"` | Image to use for the webapp if nodeModuleToInstall is set |
+| developer.nodeWorkspacesDirectories | list | `[]` | List of node workspace directories to manage in the diracx-web container (node_modules) |
 | developer.offline | bool | `false` | Make it possible to launch the demo without having an internet connection |
 | developer.sourcePath | string | `"/diracx_source"` | Path from which to mount source of DIRACX |
 | developer.urls | object | `{}` | URLs which can be used to access various components of the demo (diracx, minio, dex, etc). They are used by the diracx tests |

--- a/demo/values.tpl.yaml
+++ b/demo/values.tpl.yaml
@@ -16,6 +16,7 @@ developer:
   mountedPythonModulesToInstall: {{ mounted_python_modules }}
   editableMountedPythonModules: {{ editable_mounted_modules }}
   mountedNodeModuleToInstall: {{ node_module_to_mount }}
+  nodeWorkspacesDirectories: {{ node_module_workspaces }}
 
 diracx:
   hostname: {{ hostname }}

--- a/diracx/templates/diracx-web/deployment.yaml
+++ b/diracx/templates/diracx-web/deployment.yaml
@@ -34,14 +34,16 @@ spec:
         - name: diracx-web-code-mount
           persistentVolumeClaim:
             claimName: pvc-diracx-code
-        # These volumes override the node_modules and .next directories to
+        # These volumes override the node_modules directories to
         # start from a clean state
         - name: diracx-web-scratch-node-modules
           emptyDir:
             sizeLimit: 2Gi
-        - name: diracx-web-scratch-next
+        {{- range $module := .Values.developer.nodeWorkspacesDirectories }}
+        - name: 'diracx-web-scratch-node-modules-{{ replace "/" "-" $module -}}'
           emptyDir:
-            sizeLimit: 1Gi
+            sizeLimit: 2Gi
+        {{- end }}
         {{- else }}
         {{- if .Values.diracxWeb.branch }}
         # This volume is used to clone the specified diracx-web repository branch
@@ -91,8 +93,10 @@ spec:
               subPath: "{{ .Values.developer.mountedNodeModuleToInstall }}"
             - mountPath: "{{ $nodeMountedModulePath }}/node_modules"
               name: "diracx-web-scratch-node-modules"
-            - mountPath: "{{ $nodeMountedModulePath }}/.next"
-              name: "diracx-web-scratch-next"
+            {{- range $module := .Values.developer.nodeWorkspacesDirectories }}
+            - mountPath: "{{ $nodeMountedModulePath }}/{{ $module }}/node_modules"
+              name: 'diracx-web-scratch-node-modules-{{ replace "/" "-" $module -}}'
+            {{- end }}
           {{- else }}
           # Install the diracx-web repository, specific branch
           command: ["/bin/sh", "-c"]
@@ -136,7 +140,8 @@ spec:
           {{- if $nodeDevInstall }}
           # Start the node module in development mode
           image: {{ .Values.developer.nodeImage }}
-          command: ["npm", "run", "dev", "--prefix", "{{ $nodeMountedModulePath }}"]
+          command: ["npm", "run", "dev"]
+          workingDir: "{{ $nodeMountedModulePath }}"
           env:
             - name: NEXT_TELEMETRY_DISABLED
               value: "1"
@@ -148,8 +153,10 @@ spec:
               subPath: "{{ .Values.developer.mountedNodeModuleToInstall }}"
             - mountPath: "{{ $nodeMountedModulePath }}/node_modules"
               name: "diracx-web-scratch-node-modules"
-            - mountPath: "{{ $nodeMountedModulePath }}/.next"
-              name: "diracx-web-scratch-next"
+            {{- range $module := .Values.developer.nodeWorkspacesDirectories }}
+            - mountPath: "{{ $nodeMountedModulePath }}/{{ $module }}/node_modules"
+              name: 'diracx-web-scratch-node-modules-{{ replace "/" "-" $module -}}'
+            {{- end }}
           {{- else }}
           # Start the node module in production mode
           image: {{ .Values.global.images.web.repository }}:{{ .Values.global.images.web.tag }}

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -96,8 +96,10 @@ developer:
   # -- Use pip install -e for mountedPythonModulesToInstall
   # This is used by the integration tests because editable install might behave differently
   editableMountedPythonModules: true
-  # -- List of node modules to install
+  # -- Node module to install
   mountedNodeModuleToInstall: null
+  # -- List of node workspace directories to manage in the diracx-web container (node_modules)
+  nodeWorkspacesDirectories: []
   # -- Image to use for the webapp if nodeModuleToInstall is set
   nodeImage: node:alpine
   # -- Enable collection of coverage reports (intended for CI usage only)


### PR DESCRIPTION
The `diracx-web` repository has been refactored into a monorepo, and now contains npm workspaces:

- `diracx-web-components`: A React component library.
- `diracx-web`: A Next.js application that depends on `diracx-web-components`.

They have their own `package.json` file, but shares a common `package-lock.json` file.
Dependencies are managed collectively across the workspaces, with `npm ci` at the monorepo root creating a single `node_modules` directory at the root level to avoid duplication.
However, if there is a version conflict between dependencies in different workspaces, npm may create additional `node_modules` directories within the specific workspace directories to satisfy conflicting versions locally. (https://docs.npmjs.com/cli/v9/commands/npm-ci#install-strategy)

We have recently encountered a new version conflict between `@storybook/next` (used in `diracx-web-components`) and `next` (used in `diracx-web`). This conflict forces npm to create an additional `node_modules` directory within the `diracx-web` workspace, as each package requires a different version of certain dependencies.

This new `node_modules` directory has created permission issues in our Kubernetes deployments. When running our application in a containerized environment managed by Helm charts, this `node_modules` directory is shared between the Kubernetes process and the shared file system, leading to `Permission denied` errors (different ownership). To address this, we need to isolate all the potential `node_modules` directories created by the Helm charts from those on the local filesystem.

https://github.com/DIRACGrid/diracx-web/actions/runs/11781941013/job/32815855070?pr=243#step:10:24


Note: I remove the volume to isolate the `.next` directory. It is not located at the root anymore but in the `diracx` workspace and because it is only used by the demo (contrary to the `node_modules` directories) I think it's fine if it's shared with the local filesystem, at least for now.