### PR TITLE
fix: dbName in init_secrets

### DIFF
--- a/diracx/templates/diracx/init-secrets/_init-secrets.sh.tpl
+++ b/diracx/templates/diracx/init-secrets/_init-secrets.sh.tpl
@@ -122,8 +122,8 @@ generate_secret_if_needed diracx-sql-root-connection-urls \
   --from-literal=DIRACX_DB_URL_{{ $dbName | upper }}="{{ $root_url_string }}"
 {{- else }}
 
-{{- $url_string := urlJoin (dict "scheme" "mysql+aiomysql" "userinfo" ( print $default_db_user  ":" $default_db_password ) "host" $default_db_host "path" $db_internal_name ) }}
-{{- $root_url_string := urlJoin (dict "scheme" "mysql+aiomysql" "userinfo" ( print $default_db_root_user  ":" $default_db_root_password ) "host" $default_db_host "path" $db_internal_name ) }}
+{{- $url_string := urlJoin (dict "scheme" "mysql+aiomysql" "userinfo" ( print $default_db_user  ":" $default_db_password ) "host" $default_db_host "path" $dbName ) }}
+{{- $root_url_string := urlJoin (dict "scheme" "mysql+aiomysql" "userinfo" ( print $default_db_root_user  ":" $default_db_root_password ) "host" $default_db_host "path" $dbName ) }}
 
 generate_secret_if_needed diracx-sql-connection-urls \
   --from-literal=DIRACX_DB_URL_{{ $dbName | upper }}="{{ $url_string }}"


### PR DESCRIPTION
Error introduced in https://github.com/DIRACGrid/diracx-charts/pull/143

Error message:

```bash
$ helm upgrade lhcbdiracx diracx-charts/diracx -f values.yaml                                                                                                                                                                      
Error: UPGRADE FAILED: template: diracx/templates/diracx/init-secrets/configmap.yaml:13:8: executing "diracx/templates/diracx/init-secrets/configmap.yaml" at <include (print $.Template.BasePath "/diracx/init-secrets/_init-secrets.sh.tpl") .>: error calling include: template: diracx/templates/diracx/init-secrets/_init-secrets.sh.tpl:125:154: executing "diracx/templates/diracx/init-secrets/_init-secrets.sh.tpl" at <$db_internal_name>: undefined variable: $db_internal_name
```