### PR TITLE
Switch to dedicated health checks

### DIFF
--- a/diracx/templates/diracx/deployment.yaml
+++ b/diracx/templates/diracx/deployment.yaml
@@ -119,7 +119,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /api/docs
+              path: /api/health/live
               port: http
             timeoutSeconds: 15
             periodSeconds: 20
@@ -127,7 +127,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /api/docs
+              path: /api/health/ready
               port: http
             timeoutSeconds: 15
             periodSeconds: 20
@@ -135,7 +135,7 @@ spec:
             failureThreshold: 3
           startupProbe:
             httpGet:
-              path: /api/docs
+              path: /api/health/startup
               port: http
             timeoutSeconds: 5
             periodSeconds: 5

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -503,10 +503,11 @@ if [ ${#python_pkg_names[@]} -gt 0 ]; then
   done
 fi
 
-for diracx_compatible_pkg in "${diracx_and_extensions_pkgs[@]}"; do
-  json+="\"$diracx_compatible_pkg\","
-
-done
+if [ ${#diracx_and_extensions_pkgs[@]} -gt 0 ]; then
+  for diracx_compatible_pkg in "${diracx_and_extensions_pkgs[@]}"; do
+    json+="\"$diracx_compatible_pkg\","
+  done
+fi
 
 json="${json%,}]"
 sed "s#{{ mounted_python_modules }}#${json}#g" "${demo_dir}/values.yaml.bak" > "${demo_dir}/values.yaml"


### PR DESCRIPTION
```log
2025-04-15 14:09:14,236 - INFO: Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
2025-04-15 14:09:18,562 - INFO: 10.76.74.2:60144 - "GET /api/health/startup HTTP/1.1" 503 Service Unavailable
2025-04-15 14:09:23,576 - INFO: 10.76.74.2:36220 - "GET /api/health/startup HTTP/1.1" 200 OK
2025-04-15 14:09:24,568 - INFO: 10.76.74.2:36224 - "GET /api/health/ready HTTP/1.1" 200 OK
2025-04-15 14:09:29,226 - INFO: 2001:1458:d00:9::100:65:0 - "GET /api/auth/....
```