### PR TITLE
fix: installDiracxWeb resources

### DIFF
--- a/diracx/templates/diracx-web/deployment.yaml
+++ b/diracx/templates/diracx-web/deployment.yaml
@@ -119,13 +119,12 @@ spec:
               value: "/tmp/.cypress"
             - name: npm_config_cache
               value: "/tmp/.npm"
-          # RAM usage can be high, so we can set a larger limit if needed
-          {{- with .Values.diracxWeb.installDiracxWeb }}
-          {{- with .resources}}
+          # RAM usage can be high, so we set a larger limit
           resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- end }}
+            requests:
+              memory: 512Mi
+            limits:
+              memory: 1Gi
           volumeMounts:
             # This volume contains the source code of the cloned diracx-web repository
             - mountPath: "/diracx-web"
@@ -150,10 +149,25 @@ spec:
             httpGet:
               path: /
               port: http
+            timeoutSeconds: 15
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: http
+            timeoutSeconds: 15
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
 
           {{- if $nodeDevInstall }}
           # Start the node module in development mode

--- a/diracx/templates/diracx-web/deployment.yaml
+++ b/diracx/templates/diracx-web/deployment.yaml
@@ -120,9 +120,11 @@ spec:
             - name: npm_config_cache
               value: "/tmp/.npm"
           # RAM usage can be high, so we can set a larger limit if needed
-          {{- with .Values.diracxWeb.installDiracxWeb.resources }}
+          {{- with .Values.diracxWeb.installDiracxWeb }}
+          {{- with .resources}}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             # This volume contains the source code of the cloned diracx-web repository

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -183,12 +183,12 @@ diracxWeb:
   repoURL: ""
   branch: ""
   # -- resources to use for building the webapp if diracxWeb.repoURL is set
-  # installDiracxWeb:
-  #   resources:
-  #    requests:
-  #      memory: 512Mi
-  #    limits:
-  #      memory: 1Gi
+  installDiracxWeb:
+    resources:
+      requests:
+        memory: 512Mi
+      limits:
+        memory: 1Gi
 
 ##########################
 

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -182,13 +182,6 @@ diracxWeb:
   # -- install specification to pass to npm before launching container
   repoURL: ""
   branch: ""
-  # -- resources to use for building the webapp if diracxWeb.repoURL is set
-  installDiracxWeb:
-    resources:
-      requests:
-        memory: 512Mi
-      limits:
-        memory: 1Gi
 
 ##########################
 

--- a/docs/admin/reference/values.md
+++ b/docs/admin/reference/values.md
@@ -69,6 +69,7 @@
 | diracx.sqlDbs.dbs | string | `nil` | Which DiracX MySQL DBs are used? |
 | diracx.sqlDbs.default | string | `nil` |  |
 | diracxWeb.branch | string | `""` |  |
+| diracxWeb.installDiracxWeb | object | `{"resources":{"limits":{"memory":"1Gi"},"requests":{"memory":"512Mi"}}}` | resources to use for building the webapp if diracxWeb.repoURL is set |
 | diracxWeb.repoURL | string | `""` | install specification to pass to npm before launching container |
 | diracxWeb.service.port | int | `8080` |  |
 | elasticsearch."discovery.seed_hosts"[0] | string | `"elasticsearch-master-headless"` |  |

--- a/docs/admin/reference/values.md
+++ b/docs/admin/reference/values.md
@@ -69,7 +69,6 @@
 | diracx.sqlDbs.dbs | string | `nil` | Which DiracX MySQL DBs are used? |
 | diracx.sqlDbs.default | string | `nil` |  |
 | diracxWeb.branch | string | `""` |  |
-| diracxWeb.installDiracxWeb | object | `{"resources":{"limits":{"memory":"1Gi"},"requests":{"memory":"512Mi"}}}` | resources to use for building the webapp if diracxWeb.repoURL is set |
 | diracxWeb.repoURL | string | `""` | install specification to pass to npm before launching container |
 | diracxWeb.service.port | int | `8080` |  |
 | elasticsearch."discovery.seed_hosts"[0] | string | `"elasticsearch-master-headless"` |  |


### PR DESCRIPTION
I tried to deploy a `diracx-web` branch in `diracx-cert`: it did not work because `installDiracxWeb` was not part of `values.yaml`.

I fixed the issue in `diracx-web/deployment`, and then I got an "out of memory" error, and I added the `installDiracxWeb` section in `values.yaml`. Do you think I should comment or uncomment it by default?