### PR TITLE
fix: wait for the web pod

### DIFF
--- a/run_demo.sh
+++ b/run_demo.sh
@@ -585,7 +585,7 @@ if ! "${demo_dir}/helm" install --debug diracx-demo "${script_dir}/diracx" "${he
   echo "Failed to run \"helm install\"" >> "${demo_dir}/.failed"
 else
   printf "%b Waiting for installation to finish...\n" ${UNICORN_EMOJI}
-  if "${demo_dir}/kubectl" wait --for=condition=ready pod --selector=app.kubernetes.io/name=diracx --timeout=900s; then
+  if "${demo_dir}/kubectl" wait --for=condition=ready pod --selector='app.kubernetes.io/name in (diracx, diracx-web)' --timeout=900s; then
     printf "%b %b %b Pods are ready! %b %b %b\n" "${PARTY_EMOJI}" "${PARTY_EMOJI}" "${PARTY_EMOJI}" "${PARTY_EMOJI}" "${PARTY_EMOJI}" "${PARTY_EMOJI}"
 
     # Dump the CA certificate to a file so that it can be used by the client


### PR DESCRIPTION
Could it be a good idea to wait for the `diracx-web` pod before marking the demo as ready? It seems to help the `diracx-web` tests. I also noticed that the `diracx-web` pod always starts after the `diracx` pod.

Maybe I missed something and this is not needed. I’m looking forward to your feedback. 