### PR TITLE
fix: increase memory requested/limit to build diracx-web

### DIFF
--- a/diracx/templates/diracx-web/deployment.yaml
+++ b/diracx/templates/diracx-web/deployment.yaml
@@ -122,9 +122,9 @@ spec:
           # RAM usage can be high, so we set a larger limit
           resources:
             requests:
-              memory: 512Mi
-            limits:
               memory: 1Gi
+            limits:
+              memory: 2Gi
           volumeMounts:
             # This volume contains the source code of the cloned diracx-web repository
             - mountPath: "/diracx-web"


### PR DESCRIPTION
Last times I had to deploy a patch of `diracx-web` in the clusters, I had to manually change the memory limit values because the build process was reaching the limit.