### PR TITLE
fix: added protocols for for otel under receivers/otlp/protocols

### DIFF
--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -413,6 +413,8 @@ rabbitmq:
 cert-manager:
   enabled: true
   installCRDs: true
+  startupapicheck:
+    enabled: true
 
 cert-manager-issuer:
   enabled: true

--- a/docs/admin/reference/values.md
+++ b/docs/admin/reference/values.md
@@ -23,6 +23,7 @@
 | cert-manager-issuer.enabled | bool | `true` |  |
 | cert-manager.enabled | bool | `true` |  |
 | cert-manager.installCRDs | bool | `true` |  |
+| cert-manager.startupapicheck.enabled | bool | `true` |  |
 | developer.autoReload | bool | `true` | Enable automatic reloading inside uvicorn when the sources change Used by the integration tests for running closer to prod setup |
 | developer.editableMountedPythonModules | bool | `true` | Use pip install -e for mountedPythonModulesToInstall This is used by the integration tests because editable install might behave differently |
 | developer.enableCoverage | bool | `false` | Enable collection of coverage reports (intended for CI usage only) |


### PR DESCRIPTION
IIUC this might fix the error

```
Error: invalid configuration: receivers::otlp: must specify at least one protocol when using the OTLP receiver
```
that we see e.g. at https://github.com/DIRACGrid/diracx/actions/runs/18128670363/job/51589746354?pr=672