### PR TITLE
fix: Running the demo for extension charts

### DIFF
--- a/run_demo.sh
+++ b/run_demo.sh
@@ -622,6 +622,11 @@ fi;
 # Set the chart path to use (default to the diracx chart in this repository)
 if [[ -z "${chart_path}" ]]; then
   chart_path="${script_dir}/diracx"
+else
+  printf "%b Auto-indenting generated values into diracx section\n" ${UNICORN_EMOJI}
+  # We need to indent all the file under a new "diracx" top section
+  # shellcheck disable=SC2016
+  "${demo_dir}/yq" eval -i '. as $item ireduce ({}; .diracx += $item )' "${demo_dir}/values.yaml"
 fi
 
 if ! "${demo_dir}/helm" install --debug diracx-demo "${chart_path}" "${helm_arguments[@]}"; then


### PR DESCRIPTION
This pull request updates the `run_demo.sh` script to improve tool management and clarify the use of custom Helm charts. The most significant changes are the switch to using `arkade` for downloading required binaries, and the renaming and enhanced handling of the custom chart path option. These changes streamline the setup process and make the script more robust and user-friendly.

**Tool management improvements:**

* Replaced manual downloading of `kind`, `kubectl`, and `helm` with `arkade`, which now handles downloading these tools (as well as `yq`) into the `.demo` directory, reducing system dependencies and simplifying the script logic. (`run_demo.sh`)

**Helm chart customization enhancements:**

* Renamed the `--chart-path` option to `--extension-chart-path` for improved clarity, and updated all related help messages and error handling to match the new name. (`run_demo.sh`) [[1]](diffhunk://#diff-9561ba98374bfa0ae04e9489e6fcf01cb78e9216b1f31d6322250769bf2e96afL109-R110) [[2]](diffhunk://#diff-9561ba98374bfa0ae04e9489e6fcf01cb78e9216b1f31d6322250769bf2e96afL245-R253)
* When an extension chart is specified, automatically indents the generated values file under a new `diracx` top section using `yq`, ensuring compatibility with umbrella charts. (`run_demo.sh`)