### PR TITLE
feat: pin versions of kind, kubectl, helm, yq, and helm-diff

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Group all tool version updates together",
+      "matchDatasources": ["github-releases"],
+      "matchFileNames": ["run_demo.sh"],
+      "groupName": "demo script tool versions"
+    },
+    {
+      "description": "Pin Helm to 3.x to avoid v4 verification issues",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["helm/helm"],
+      "allowedVersions": "<4.0.0"
+    }
+  ],
+  "regexManagers": [
+    {
+      "description": "Update tool versions in run_demo.sh",
+      "fileMatch": ["^run_demo\\.sh$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\n\\s*[A-Z_]+_VERSION=\"(?<currentValue>.*)\"",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\n\\s*[A-Z_]+_VERSION='(?<currentValue>.*)'"
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ]
+}

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -380,12 +380,28 @@ if [[ ! -f "${demo_dir}/helm" ]]; then
     chmod +x "${demo_dir}/arkade"
   fi
 
-  # Use arkade to download the required tools
+  # Use arkade to download the required tools with pinned versions
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+  KIND_VERSION="v0.30.0"
+  # renovate: datasource=github-releases depName=kubernetes/kubernetes
+  KUBECTL_VERSION="v1.31.4"
+  # renovate: datasource=github-releases depName=helm/helm versioning=loose
+  HELM_VERSION="v3.19.2"
+  # renovate: datasource=github-releases depName=mikefarah/yq
+  YQ_VERSION="v4.48.2"
+
   printf "%b Downloading kind, kubectl, helm and yq using arkade\n" ${UNICORN_EMOJI}
-  "${demo_dir}/arkade" get kind kubectl helm yq --path "${demo_dir}"
+  "${demo_dir}/arkade" get \
+    kind@${KIND_VERSION} \
+    kubectl@${KUBECTL_VERSION} \
+    helm@${HELM_VERSION} \
+    yq@${YQ_VERSION} \
+    --path "${demo_dir}"
 
   # Install helm plugins to ${HELM_DATA_HOME}
-  "${demo_dir}/helm" plugin install https://github.com/databus23/helm-diff
+  # renovate: datasource=github-releases depName=databus23/helm-diff
+  HELM_DIFF_VERSION="v3.13.1"
+  "${demo_dir}/helm" plugin install https://github.com/databus23/helm-diff --version ${HELM_DIFF_VERSION}
 fi
 
 # Exit early if we're only downloading dependencies


### PR DESCRIPTION
Pin tool versions in run_demo.sh to ensure reproducible builds:
- kind: v0.30.0
- kubectl: v1.31.4
- helm: v3.19.2 (pinned to 3.x to avoid v4 verification issues)
- yq: v4.48.2
- helm-diff: v3.13.1

Add renovate.json configuration to automatically update these versions using renovate's regex manager. Helm is restricted to 3.x versions to avoid verification issues in v4.