### PR TITLE
ci: skip version check and release for infrastructure-only PRs

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -48,17 +48,19 @@ jobs:
 
   check-version-bump:
     needs: detect-chart-changes
-    if: github.event_name == 'pull_request' && needs.detect-chart-changes.outputs.charts-changed == 'true'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - name: Checkout
+        if: needs.detect-chart-changes.outputs.charts-changed == 'true'
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Check for version bumps
+        if: needs.detect-chart-changes.outputs.charts-changed == 'true'
         run: |
           set -e
 


### PR DESCRIPTION
## Summary

- Merge `version-check.yml` and `release.yml` into a single `chart-ci.yml` workflow
- A shared `detect-chart-changes` job checks which files were modified
- The `check-version-bump` and `release` jobs are skipped when no files inside a chart directory were changed
- Infrastructure-only PRs (e.g. #223, #224) no longer require a chart version bump