### PR TITLE
fix: use services image for validate-config job

### DIFF
--- a/diracx/Chart.yaml
+++ b/diracx/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.9"
+version: "1.0.10"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/diracx/templates/diracx/validate-config/job.yaml
+++ b/diracx/templates/diracx/validate-config/job.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.global.images.client }}:{{ .Values.global.images.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.global.images.services }}:{{ .Values.global.images.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command: ["/bin/bash", "/entrypoint.sh"]
           args: ["/bin/bash", "/scripts/validate-config"]


### PR DESCRIPTION
## Summary
- The validate-config job was using the client image (`global.images.client`) instead of the services image (`global.images.services`)
- Changed to use the same image as the services deployment
- Bumped chart version from 1.0.9 to 1.0.10