### PR TITLE
chore: consolidate dependency management to Renovate-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
+    {
+      "description": "Require dashboard approval for Helm chart dependency updates",
+      "matchManagers": ["helmv3"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Group all GitHub Actions updates together",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    },
     {
       "description": "Group all tool version updates together",
       "matchDatasources": ["github-releases"],
@@ -17,9 +26,10 @@
       "allowedVersions": "<4.0.0"
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
       "description": "Update tool versions in run_demo.sh",
+      "customType": "regex",
       "fileMatch": ["^run_demo\\.sh$"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\n\\s*[A-Z_]+_VERSION=\"(?<currentValue>.*)\"",


### PR DESCRIPTION
## Summary

- Remove Dependabot (`.github/dependabot.yml`) — Renovate's built-in `github-actions` manager replaces it
- Add `minimumReleaseAge: "7 days"` on all dependencies for supply chain protection (see [We should all be using dependency cooldowns](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns))
- Require dashboard approval for Helm chart updates so maintainers opt in
- Group GitHub Actions updates into a single PR to reduce noise
- Modernize deprecated `regexManagers` key to `customManagers`

## Resulting behavior

| Dependency type | Auto-PR? | Cooldown | Grouping |
|---|---|---|---|
| Helm charts (`diracx/Chart.yaml`) | No — dashboard approval required | 7 days | Individual per chart |
| GitHub Actions (`.github/workflows/`) | Yes | 7 days | Single "GitHub Actions" PR |
| Demo script tools (`run_demo.sh`) | Yes | 7 days | Single "demo script tool versions" PR |