### PR TITLE
Allow user defined volumes/volumeMounts for diracx pod

### DIFF
--- a/diracx/Chart.yaml
+++ b/diracx/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.22"
+version: "1.0.23"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/diracx/templates/diracx/deployment.yaml
+++ b/diracx/templates/diracx/deployment.yaml
@@ -64,6 +64,9 @@ spec:
           persistentVolumeClaim:
             claimName: pvc-coverage
         {{- end }}
+        {{- with .Values.diracx.extraVolumes }}
+        {{- . | toYaml | nindent  8 }}
+        {{- end}}
 
       {{/* Define common volume mounts for reusability */}}
       {{- $commonVolumeMounts := list }}
@@ -155,7 +158,11 @@ spec:
             - "--reload-dir={{ .Values.developer.sourcePath }}"
             {{- end }}
           {{- end }}
-          volumeMounts: {{ toYaml $commonVolumeMounts | nindent 12 }}
+          volumeMounts:
+            {{- toYaml $commonVolumeMounts | nindent 12 }}
+            {{- with .Values.diracx.extraVolumeMounts }}
+            {{- . | toYaml | nindent  12 }}
+            {{- end}}
           envFrom:
             # - configMapRef:
             #     name: diracx-env-config

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -178,6 +178,12 @@ diracx:
     DIRACX_OTEL_GRPC_ENDPOINT: "diracx-demo-opentelemetry-collector:4317"
     DIRACX_OTEL_GRPC_INSECURE: "true"
 
+  # -- Additional volumes for the diracx pod, e.g. to mount CA certificates
+  extraVolumes:
+
+  # -- Additional volumeMounts for the diracx pod, e.g. to mount CA certificates
+  extraVolumeMounts:
+
   # If mysql is enabled, you are not allowed
   # to set the username passwords
   sqlDbs:

--- a/docs/admin/reference/values.md
+++ b/docs/admin/reference/values.md
@@ -62,6 +62,8 @@
 | dex.service.ports.http.nodePort | int | `32002` |  |
 | dex.service.ports.http.port | int | `8000` |  |
 | dex.service.type | string | `"NodePort"` |  |
+| diracx.extraVolumeMounts | string | `nil` | Additional volumeMounts for the diracx pod, e.g. to mount CA certificates |
+| diracx.extraVolumes | string | `nil` | Additional volumes for the diracx pod, e.g. to mount CA certificates |
 | diracx.hostname | string | `""` | Required: The hostname where the webapp/API is running |
 | diracx.osDbs.dbs | string | `nil` | Which DiracX OpenSearch DBs are used? |
 | diracx.osDbs.default | string | `nil` |  |


### PR DESCRIPTION
For our integration tests and in prod, we need to mount a volume of CA certificates (the EGI trust store), but the diracx chart does not allow user-defined extra volumes.


Closes #259

cc @volodymyrss @natthan-pigoux 