### PR TITLE
fix: validate config against ephemeral secret

### DIFF
--- a/diracx/Chart.yaml
+++ b/diracx/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.1.0-beta.1"
+version: "1.1.0-beta.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/diracx/templates/diracx/secrets.yaml
+++ b/diracx/templates/diracx/secrets.yaml
@@ -2,9 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: diracx-secrets
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-10"
 stringData:
 {{ .Values.diracx.settings | toYaml | indent 2 }}
 ---

--- a/diracx/templates/diracx/validate-config/job.yaml
+++ b/diracx/templates/diracx/validate-config/job.yaml
@@ -48,7 +48,7 @@ spec:
               mountPath: /scripts
           envFrom:
             - secretRef:
-                name: diracx-secrets
+                name: diracx-validate-config-secrets
       volumes:
       {{- if .Values.developer.enabled }}
       - name: cs-store-mount

--- a/diracx/templates/diracx/validate-config/secrets.yaml
+++ b/diracx/templates/diracx/validate-config/secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: diracx-validate-config-secrets
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": post-install,pre-upgrade
     "helm.sh/hook-weight": "-6"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 stringData:

--- a/diracx/templates/diracx/validate-config/secrets.yaml
+++ b/diracx/templates/diracx/validate-config/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: diracx-validate-config-secrets
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-6"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+stringData:
+{{ .Values.diracx.settings | toYaml | indent 2 }}
+---

--- a/docs/admin/explanations/architecture_diagram.md
+++ b/docs/admin/explanations/architecture_diagram.md
@@ -5,7 +5,7 @@ config:
 flowchart TD
 
     subgraph k8s_instance ["K8s Instance: diracx"]
-        subgraph helm_chart ["Helm Chart: diracx-1.1.0 beta.1"]
+        subgraph helm_chart ["Helm Chart: diracx-1.1.0 beta.2"]
             subgraph k8s_app ["K8s Application: diracx"]
                 ing_diracx{{"ing: diracx"}}
                 svc_diracx(("svc: diracx"))
@@ -21,6 +21,7 @@ flowchart TD
                 cronjob_diracx_cleanup_authdb(["cronjob: diracx-cleanup-authdb"])
                 cm_diracx_cleanup_authdb[("cm: diracx-cleanup-authdb")]
                 cm_mysql_init_diracx_dbs[("cm: mysql-init-diracx-dbs")]
+                secret_diracx_secrets>"secret: diracx-secrets"]
                 sa_diracx[["sa: diracx"]]
             end
 
@@ -36,7 +37,7 @@ flowchart TD
 
             subgraph hook_pre_install_pre_upgrade ["pre-install,pre-upgrade"]
                 cm_diracx_container_entrypoint[("cm: diracx-container-entrypoint")]
-                secret_diracx_secrets>"secret: diracx-secrets"]
+                secret_diracx_validate_config_secrets>"secret: diracx-validate-config-secrets"]
             end
         end
     end
@@ -69,7 +70,7 @@ flowchart TD
     job_diracx_init_keystore -->|"mounts"| cm_diracx_container_entrypoint
     job_diracx_validate_config -->|"mounts"| cm_diracx_validate_config
     job_diracx_validate_config -->|"mounts"| cm_diracx_container_entrypoint
-    job_diracx_validate_config -->|"env"| secret_diracx_secrets
+    job_diracx_validate_config -->|"env"| secret_diracx_validate_config_secrets
     cronjob_diracx_cleanup_authdb -->|"mounts"| cm_diracx_cleanup_authdb
     cronjob_diracx_cleanup_authdb -->|"mounts"| cm_diracx_container_entrypoint
     cronjob_diracx_cleanup_authdb -->|"env"| secret_diracx_secrets
@@ -99,6 +100,7 @@ flowchart TD
     class job_diracx_init_keystore job
     class job_diracx_validate_config job
     class secret_diracx_secrets secret
+    class secret_diracx_validate_config_secrets secret
     class svc_diracx svc
     class svc_diracx_task_redis svc
     class svc_diracx_web svc

--- a/docs/admin/explanations/architecture_diagram.md
+++ b/docs/admin/explanations/architecture_diagram.md
@@ -28,6 +28,7 @@ flowchart TD
             subgraph hook_post_install_pre_upgrade ["post-install,pre-upgrade"]
                 cm_diracx_validate_config[("cm: diracx-validate-config")]
                 job_diracx_validate_config(["job: diracx-validate-config"])
+                secret_diracx_validate_config_secrets>"secret: diracx-validate-config-secrets"]
             end
 
             subgraph hook_pre_install ["pre-install"]
@@ -37,7 +38,6 @@ flowchart TD
 
             subgraph hook_pre_install_pre_upgrade ["pre-install,pre-upgrade"]
                 cm_diracx_container_entrypoint[("cm: diracx-container-entrypoint")]
-                secret_diracx_validate_config_secrets>"secret: diracx-validate-config-secrets"]
             end
         end
     end


### PR DESCRIPTION
#262 made diracx-secrets a pre-upgrade hook so validate-config (also pre-upgrade, weight -4) would see fresh settings before pods rolled. That converted a previously tracked Secret into a hook resource, which breaks upgrades from <=1.0.x: Helm's manifest reconciliation deletes diracx-secrets (it's no longer in the regular manifest) after the hook recreates it, and deployments fail with CreateContainerConfigError.

Instead, render an ephemeral diracx-validate-config-secrets (pre hook, weight -6, hook-succeeded delete) from the same .Values.diracx.settings and have validate-config envFrom that. diracx-secrets goes back to being a regular tracked resource, patched in place by the normal upgrade flow. Pre-upgrade validation still gates the rollout.