### PR TITLE
ci: add upgrade-path regression test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,66 @@ jobs:
           exit 1
         fi
 
+  # Install the latest released chart, then upgrade to the PR's chart.
+  # Catches upgrade-time regressions (e.g. PR #262, which converted
+  # diracx-secrets from a regular resource to a hook and consequently
+  # deleted it during upgrades from <= 1.0.x).
+  run-upgrade-test:
+    needs: detect-docs-only
+    if: needs.detect-docs-only.outputs.docs-only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        # Tags are needed for `git worktree add` against the released ref.
+        # actions/checkout doesn't fetch tags by default even with depth: 0.
+    - name: Fetch tags
+      run: git fetch --tags --force
+    - name: Discover latest release
+      id: discover
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: scripts/upgrade-test/discover-latest-release.sh
+    - name: Skip notice
+      if: steps.discover.outputs.skip == 'true'
+      run: echo "::notice::${{ steps.discover.outputs.skip_reason }}; skipping upgrade test"
+    - name: Worktree the released chart
+      if: steps.discover.outputs.skip != 'true'
+      run: git worktree add /tmp/released-chart "${{ steps.discover.outputs.tag }}"
+    - name: Bring up cluster + install released chart
+      if: steps.discover.outputs.skip != 'true'
+      run: /tmp/released-chart/run_demo.sh --exit-when-done
+    - name: Add released chart's helm/kubectl to PATH
+      if: steps.discover.outputs.skip != 'true'
+      run: echo "/tmp/released-chart/.demo" >> "$GITHUB_PATH"
+    - name: Upgrade to PR chart
+      if: steps.discover.outputs.skip != 'true'
+      env:
+        KUBECONFIG: /tmp/released-chart/.demo/kube.conf
+        HELM_DATA_HOME: /tmp/released-chart/.demo/helm_data
+      run: |
+        HELM=/tmp/released-chart/.demo/helm
+        "$HELM" dependency build "$GITHUB_WORKSPACE/diracx"
+        "$HELM" upgrade --debug --atomic --wait --timeout 900s \
+          diracx-demo "$GITHUB_WORKSPACE/diracx" \
+          --values /tmp/released-chart/.demo/values.yaml
+    - name: Assert upgrade healthy
+      if: steps.discover.outputs.skip != 'true'
+      env:
+        KUBECONFIG: /tmp/released-chart/.demo/kube.conf
+        HELM_DATA_HOME: /tmp/released-chart/.demo/helm_data
+      run: scripts/upgrade-test/assert-upgrade-healthy.sh
+    - name: Diagnostics
+      if: always() && steps.discover.outputs.skip != 'true'
+      env:
+        KUBECONFIG: /tmp/released-chart/.demo/kube.conf
+        HELM_DATA_HOME: /tmp/released-chart/.demo/helm_data
+      run: scripts/upgrade-test/collect-diagnostics.sh
+
   # Same as run-demo except mount the sources inside the container
   # Uses ci_values.yaml to override image tags to "dev"
   run-demo-mount-sources:

--- a/scripts/upgrade-test/assert-upgrade-healthy.sh
+++ b/scripts/upgrade-test/assert-upgrade-healthy.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Post-upgrade assertions for the run-upgrade-test job.
+#
+# Each named regression that's worth catching is one block here. When you add
+# a new check, comment it with the PR/issue that motivated it so the next
+# reader knows why this exact resource is being asserted.
+#
+# Requires KUBECONFIG to point at the kind cluster, and helm/kubectl on PATH
+# (the workflow exports the released-tree's .demo/ binaries).
+
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# 1. Helm release status should be "deployed" (not "failed", not "pending").
+helm status diracx-demo -o json | jq -e '.info.status == "deployed"' >/dev/null \
+  || fail "helm release status is not 'deployed'"
+
+# 2. PR #262 regression: pre-upgrade hook deleted diracx-secrets and Helm's
+#    manifest reconciliation never restored it. Asserts the Secret exists
+#    after the upgrade.
+kubectl get secret diracx-secrets -o name >/dev/null \
+  || fail "diracx-secrets Secret is missing after upgrade (regression of PR #262)"
+
+# 3. All Pods become Ready within a bounded window. Catches the broad class
+#    of "upgrade succeeded but something CrashLoopBackOffs / FailedMounts".
+kubectl wait --for=condition=Ready pod --all --timeout=600s \
+  || fail "not all pods became Ready after upgrade"
+
+# 4. No failed Helm hook Jobs. Catches the case where an upgrade hook (e.g.
+#    validate-config) regressed and the upgrade somehow proceeded anyway.
+failed_jobs=$(kubectl get jobs -o json \
+  | jq -r '[.items[] | select((.status.failed // 0) > 0) | .metadata.name] | join(",")')
+if [[ -n "$failed_jobs" ]]; then
+  fail "failed Job(s) detected: $failed_jobs"
+fi
+
+# 5. Helm history shows a fresh deployed revision and the previous one
+#    superseded. Catches the case where a previous step looked successful
+#    but Helm didn't actually record the upgrade.
+helm history diracx-demo -o json \
+  | jq -e 'map({rev: .revision, status: .status})
+           | (any(.[]; .rev == 2 and .status == "deployed"))
+           and (any(.[]; .rev == 1 and .status == "superseded"))' >/dev/null \
+  || fail "helm history not as expected (rev 2 deployed, rev 1 superseded)"
+
+echo "All upgrade-health assertions passed."

--- a/scripts/upgrade-test/collect-diagnostics.sh
+++ b/scripts/upgrade-test/collect-diagnostics.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Failure-time dump for the run-upgrade-test job. Always runs (even on
+# success) so the workflow log is self-contained. Exit code is ignored;
+# this script never fails the job by itself.
+
+set +e
+
+section() {
+  echo
+  echo "=============================================================="
+  echo "=== $* ==="
+  echo "=============================================================="
+}
+
+section "helm history"
+helm history diracx-demo
+
+section "helm status"
+helm status diracx-demo
+
+section "all resources"
+kubectl get all -A
+
+section "pods (full)"
+kubectl get pods -o wide
+
+section "non-Ready pods (describe)"
+kubectl get pods --no-headers \
+  | awk '$2 !~ /^([0-9]+)\/\1$/ || $3 != "Running" { print $1 }' \
+  | xargs -r -n1 kubectl describe pod
+
+section "recent warning events"
+kubectl get events --field-selector type=Warning --sort-by=.lastTimestamp
+
+section "secrets and configmaps"
+kubectl get secret,configmap
+
+exit 0

--- a/scripts/upgrade-test/discover-latest-release.sh
+++ b/scripts/upgrade-test/discover-latest-release.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Discover the latest published chart release to upgrade from.
+#
+# Sets $GITHUB_OUTPUT entries:
+#   tag           - the released git tag (e.g. "diracx-1.1.0-beta.1")
+#   version       - just the version part (e.g. "1.1.0-beta.1")
+#   skip          - "true" if the upgrade test should be skipped
+#   skip_reason   - human-readable reason when skip=true
+#
+# Skip conditions:
+#   - no prior diracx-* release exists
+#   - PR's diracx/Chart.yaml version equals the latest released version
+#     (chart-ci.yml's check-version-bump is the right place to enforce that
+#     templates+version-bump come together; we just avoid a redundant failure)
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+  echo "GITHUB_OUTPUT is not set; this script is intended to run in GitHub Actions" >&2
+  exit 1
+fi
+
+# chart-releaser-action publishes drafts as a workaround for immutable releases
+# (see chart-ci.yml). Excluding drafts gets us the actual published versions.
+# Prereleases are included on purpose — the project ships betas as the public
+# version and we want each beta to upgrade cleanly from its predecessor.
+candidates=$(gh release list --limit 50 \
+  --json tagName,isDraft,isPrerelease,publishedAt \
+  | jq -r '.[]
+           | select(.isDraft | not)
+           | select(.tagName | startswith("diracx-"))
+           | "\(.publishedAt) \(.tagName)"' \
+  | sort)
+
+latest_tag=$(echo "$candidates" | awk 'NF{print $2}' | tail -n1)
+
+if [[ -z "$latest_tag" ]]; then
+  {
+    echo "skip=true"
+    echo "skip_reason=no prior diracx-* release found"
+  } >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+released_version="${latest_tag#diracx-}"
+pr_version=$(grep -E '^version:' diracx/Chart.yaml | head -n1 \
+  | sed -E 's/^version:[[:space:]]*"?([^"]+)"?[[:space:]]*$/\1/')
+
+if [[ "$pr_version" == "$released_version" ]]; then
+  {
+    echo "skip=true"
+    echo "skip_reason=PR Chart.yaml version equals released version ($pr_version)"
+  } >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+{
+  echo "tag=$latest_tag"
+  echo "version=$released_version"
+  echo "skip=false"
+} >> "$GITHUB_OUTPUT"
+
+echo "Will test upgrade $released_version -> $pr_version"


### PR DESCRIPTION
Install the latest released chart, then helm upgrade --atomic to the PR's working-tree chart, on a kind cluster. Catches the class of bug where a chart change that's harmless on a fresh install breaks the upgrade path — e.g. PR #262 converting diracx-secrets from a regular resource to a hook, which silently deleted the Secret during upgrades from <= 1.0.x.

The job reuses the released-tag's own run_demo.sh via 'git worktree add' so the install step is coherent with that chart version (its own demo/values.tpl.yaml etc.). After the install, --atomic upgrade runs against the PR tree; assertions check helm release status, key release resources still exist, all pods Ready, no failed hook Jobs, helm history advanced. Diagnostics always run.

Skips cleanly when there's no prior release, when Chart.yaml version is unchanged, or when the PR is docs-only.