### PR TITLE
feat: add ResourceStatusDB to the database list

### DIFF
--- a/demo/values.tpl.yaml
+++ b/demo/values.tpl.yaml
@@ -41,6 +41,7 @@ diracx:
       SandboxMetadataDB:
       TaskQueueDB:
       PilotAgentsDB:
+      ResourceStatusDB:
   osDbs:
     dbs:
       JobParametersDB:


### PR DESCRIPTION
Adds the new `ResourceStatusDB` from RSS phase 1 to the list of sql databases.

Needed for https://github.com/DIRACGrid/diracx/pull/910 integration tests and therefore linked to https://github.com/DIRACGrid/diracx/issues/839.