### PR TITLE
docs: rename AuthDB retention env var hint to RETENTION_MONTHS

### DIFF
--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -214,7 +214,7 @@ diracx:
     DIRACX_SERVICE_AUTH_ALLOWED_REDIRECTS: '["http://anything:8000/docs/oauth2-redirect"]'
 
     # -- Tune the AuthDB cleanup cronjob retention periods
-    # -- DIRACX_SERVICE_AUTH_REVOKED_REFRESH_TOKEN_RETENTION_MINUTES: <minutes>
+    # -- DIRACX_SERVICE_AUTH_REFRESH_TOKEN_RETENTION_MONTHS: <months>
     # -- DIRACX_SERVICE_AUTH_COMPLETED_FLOW_RETENTION_MINUTES: <minutes>
 
     # -- legacy exchange key for DIRAC legacy (see https://github.com/DIRACGrid/diracx/blob/7f766158a674fde0eed011cd2745d359e507f846/diracx-routers/src/diracx/routers/auth/token.py#L264)


### PR DESCRIPTION
The refresh-token retention env var was renamed from DIRACX_SERVICE_AUTH_REVOKED_REFRESH_TOKEN_RETENTION_MINUTES to DIRACX_SERVICE_AUTH_REFRESH_TOKEN_RETENTION_MONTHS in diracx (cleanup now drops monthly partitions instead of deleting rows). Update the tuning hint in values.yaml accordingly.

See https://github.com/DIRACGrid/diracx/pull/929