### PR TITLE
fix: correct broken release link in upgrading how-to

### DIFF
--- a/docs/admin/how-to/upgrading.md
+++ b/docs/admin/how-to/upgrading.md
@@ -29,4 +29,4 @@ Some tools can assist you managing clusters. There are two main tools: ``ArgoCD`
 
 ### Gitlab automation
 
-The steps involved into automating the release process using gitlab CI are easy, and are described in the [installation how-to](../../dev//how-to/make-a-release.md)
+The steps involved into automating the release process using gitlab CI are easy, and are described in the [release how-to](make-a-release.md)


### PR DESCRIPTION
The link pointed to `../../dev//how-to/make-a-release.md`, which does not exist. `make-a-release.md` lives in the same directory, so this broke the strict docs build of the merged diracx site.