### PR TITLE
remove initOS condition in init-secrets

### DIFF
--- a/diracx/Chart.yaml
+++ b/diracx/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.1.5"
+version: "1.1.6"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/diracx/templates/diracx/init-secrets/_init-secrets.sh.tpl
+++ b/diracx/templates/diracx/init-secrets/_init-secrets.sh.tpl
@@ -145,7 +145,6 @@ generate_secret_if_needed diracx-task-redis-url \
 {{- end }}
 {{- end }}
 
-{{- if .Values.initOs.enabled }}
 # If we deploy opensearch ourselves
 {{- if .Values.opensearch.enabled }}
 
@@ -196,8 +195,6 @@ generate_secret_if_needed diracx-os-connection-urls \
   --from-literal=DIRACX_OS_DB_{{ $osDbName | upper }}='{"hosts": "{{ $defaultOsDbUser }}:{{ $defaultOsDbPassword }}@{{ $defaultOsDbHost }}", "use_ssl": true, "verify_certs": false}'
 generate_secret_if_needed diracx-os-root-connection-urls \
   --from-literal=DIRACX_OS_DB_{{ $osDbName | upper }}='{"hosts": "{{ $defaultOsDbRootUser }}:{{ $defaultOsDbRootPassword }}@{{ $defaultOsDbHost }}", "use_ssl": true, "verify_certs": false}'
-{{- end }}
-
 {{- end }}
 {{- end }}
 {{- end }}

--- a/docs/admin/explanations/architecture_diagram.md
+++ b/docs/admin/explanations/architecture_diagram.md
@@ -5,7 +5,7 @@ config:
 flowchart TD
 
     subgraph k8s_instance ["K8s Instance: diracx"]
-        subgraph helm_chart ["Helm Chart: diracx 1.1.5"]
+        subgraph helm_chart ["Helm Chart: diracx 1.1.6"]
             subgraph k8s_app ["K8s Application: diracx"]
                 ing_diracx{{"ing: diracx"}}
                 svc_diracx(("svc: diracx"))


### PR DESCRIPTION
OS secrets creation does not need initOS to be enabled.
This PR aims at allowing OS secrets creation even if initOS is disabled.
In the case we don't have permission to create OS templates on the fly, we have to set initOS.enabled to false, but we need to create OS secrets.