### PR TITLE
Add support to specify seaweeds ports values in values.yaml

### DIFF
--- a/diracx/Chart.yaml
+++ b/diracx/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.1.6"
+version: "1.1.7"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/diracx/templates/seaweedfs/seaweedfs.yaml
+++ b/diracx/templates/seaweedfs/seaweedfs.yaml
@@ -14,13 +14,13 @@ spec:
     release: {{ .Release.Name }}
   ports:
     - name: s3
-      port: 8333
-      targetPort: 8333
-      nodePort: 32000
+      port: {{ default 8333 .Values.seaweedfs.s3Port }}
+      targetPort: {{ default 8333 .Values.seaweedfs.s3TargetPort }}
+      nodePort: {{ default 32000 .Values.seaweedfs.s3NodePort }}
     - name: adminui
-      port: 23646
-      targetPort: 23646
-      nodePort: 32001
+      port: {{ default 23646 .Values.seaweedfs.adminuiPort }}
+      targetPort: {{ default 23646 .Values.seaweedfs.adminuiTargetPort }}
+      nodePort: {{ default 32001 .Values.seaweedfs.adminuiNodePort }}
   type: NodePort
 ---
 # PersistentVolumeClaim
@@ -76,9 +76,9 @@ spec:
             - name: S3_BUCKET
               value: {{ .Values.seaweedfs.config.bucket }}
           ports:
-            - containerPort: 8333
+            - containerPort: {{ default 8333 .Values.seaweedfs.s3Port }}
               name: s3
-            - containerPort: 23646
+            - containerPort: {{ default 23646 .Values.seaweedfs.adminuiPort }}
               name: adminui
           volumeMounts:
             - name: seaweedfs-data

--- a/diracx/templates/seaweedfs/seaweedfs.yaml
+++ b/diracx/templates/seaweedfs/seaweedfs.yaml
@@ -64,7 +64,7 @@ spec:
     spec:
       containers:
         - name: seaweedfs
-          image: "chrislusf/seaweedfs:4.23"
+          image: "chrislusf/seaweedfs:{{ .Values.seaweedfs.image.tag }}"
           imagePullPolicy: IfNotPresent
           args: [
             {{ .Values.seaweedfs.mode | quote }},

--- a/diracx/values.yaml
+++ b/diracx/values.yaml
@@ -372,6 +372,8 @@ opensearch:
 seaweedfs:
   enabled: false
   mode: "mini"
+  image:
+    tag: 4.23
   persistence:
     size: 1Gi
     storageClass: "standard"

--- a/docs/admin/explanations/architecture_diagram.md
+++ b/docs/admin/explanations/architecture_diagram.md
@@ -5,7 +5,7 @@ config:
 flowchart TD
 
     subgraph k8s_instance ["K8s Instance: diracx"]
-        subgraph helm_chart ["Helm Chart: diracx 1.1.6"]
+        subgraph helm_chart ["Helm Chart: diracx 1.1.7"]
             subgraph k8s_app ["K8s Application: diracx"]
                 ing_diracx{{"ing: diracx"}}
                 svc_diracx(("svc: diracx"))

--- a/docs/admin/reference/values.md
+++ b/docs/admin/reference/values.md
@@ -242,6 +242,7 @@
 | seaweedfs.config.configMap.data."seaweedfs-s3.json" | string | `"{\n  \"identities\": [\n    {\n      \"name\": \"admin\",\n      \"credentials\": [\n        {\n          \"accessKey\": \"console\",\n          \"secretKey\": \"console123\"\n        }\n      ],\n      \"actions\": [\"Admin\", \"Read\", \"Write\", \"List\", \"Tagging\"]\n    }\n  ]\n}\n"` |  |
 | seaweedfs.config.configMap.name | string | `"seaweedfs-s3-config"` |  |
 | seaweedfs.enabled | bool | `false` |  |
+| seaweedfs.image.tag | float | `4.23` |  |
 | seaweedfs.mode | string | `"mini"` |  |
 | seaweedfs.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | seaweedfs.persistence.size | string | `"1Gi"` |  |


### PR DESCRIPTION
This is my first PR to diracx-charts. 

Fixes: https://github.com/DIRACGrid/diracx-charts/issues/291, https://github.com/DIRACGrid/diracx-charts/issues/288

It provides the following changes:
- replaced hardcoded spec.ports values in `diracx/templates/seaweedfs/seaweedfs.yaml` with appropriate placehoders provided via `values.yaml`
- apply corresponding defaults if these port values will not be specified in user specific manifest